### PR TITLE
add `curve_libsodium` option to build.rs

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -22,10 +22,17 @@ pub fn build(b: *std.Build) void {
         "Omit debug symbols",
     ) orelse (optimize != .Debug);
 
+    const curve_libsodium = b.option(
+        bool,
+        "curve_libsodium",
+        "Include libsodium for curve support",
+    ) orelse false;
+
     const options: Options = .{
         .poller = poller,
         .draft = draft,
         .use_radix_tree = use_radix_tree,
+        .curve_libsodium = curve_libsodium,
     };
 
     const libzmq = buildLibzmq(
@@ -138,6 +145,7 @@ const Options = struct {
     poller: Poller,
     draft: bool,
     use_radix_tree: bool,
+    curve_libsodium: bool,
 };
 
 const shared_values = .{
@@ -349,8 +357,6 @@ const linux_values = .{
     // TODO: Add an option for enabling NORM
     // TODO: Add an option for enabling VMCI
 
-    // TODO: Add an option for enabling CURVE
-    // TODO: Add an option for using libsodium
     // TODO: Add an option for using libgssapi_krb5
     // TODO: Add an option for enabling TLS and find a way to find and link GnuTLS
 
@@ -480,6 +486,18 @@ fn buildLibzmq(
     });
     library.linkLibC();
     library.linkLibCpp();
+
+    if (options.curve_libsodium) {
+        const maybe_sodium = b.lazyDependency("libsodium", .{ .shared = false, .static = true });
+        if (maybe_sodium) |sodium| {
+            platform.addValues(.{ .ZMQ_HAVE_CURVE = true, .ZMQ_USE_LIBSODIUM = true });
+            library.linkLibrary(sodium.artifact("sodium"));
+            library.addIncludePath(sodium.path("src/libsodium/include"));
+        } else {
+            const no_sodium = b.addFail("failed to load lazy dependency libsodium");
+            platform.step.dependOn(&no_sodium.step);
+        }
+    }
 
     library.root_module.addIncludePath(platform.getOutput().dirname());
     if (options.draft) {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,7 +12,7 @@
         .libsodium = .{
             .url = "git+https://github.com/jedisct1/libsodium#7f7873c21b5819f45927ecd344ac047ffb8b1a00",
             .hash = "N-V-__8AAJ2dYwDtsWQvo58_eb7kC8QOJVIwwRjulq-rbWMV",
-            .lazx = true,
+            .lazy = true,
         },
     },
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,6 +9,11 @@
             .url = "https://github.com/zeromq/libzmq/archive/34f7fa22022bed9e0e390ed3580a1c83ac4a2834.tar.gz",
             .hash = "N-V-__8AAHUzRQAL7Ikh0_T9Nw0RdIaq1ntd_qhYGJA9AvC6",
         },
+        .libsodium = .{
+            .url = "git+https://github.com/jedisct1/libsodium#7f7873c21b5819f45927ecd344ac047ffb8b1a00",
+            .hash = "N-V-__8AAJ2dYwDtsWQvo58_eb7kC8QOJVIwwRjulq-rbWMV",
+            .lazx = true,
+        },
     },
 
     .paths = .{


### PR DESCRIPTION
Hi,
I've implemented the required changes into `build.rs` to enable curveZMQ support.

I've also tried to add gssapi support using krb5, but as krb5 doesn't have a build.zig I deemed it too much effort.